### PR TITLE
[codex] Fix SuperSplat loading external PLY files

### DIFF
--- a/app/core/superplat_engine.py
+++ b/app/core/superplat_engine.py
@@ -91,11 +91,7 @@ class SuperSplatEngine(BaseEngine):
         """
         self.stop_data_server()
 
-        dir_path = Path(directory).resolve()
-        # Prevent path traversal – only allow directories inside the project root.
-        project_root = resolve_project_root().resolve()
-        if not str(dir_path).startswith(str(project_root)):
-            return False, "Dossier de données hors du répertoire du projet"
+        dir_path = Path(directory).expanduser().resolve()
         if not dir_path.is_dir():
             return False, "Dossier de données introuvable"
 
@@ -117,6 +113,7 @@ class SuperSplatEngine(BaseEngine):
             from functools import partial
             handler = partial(CORSRequestHandler, directory=str(dir_path))
             try:
+                socketserver.TCPServer.allow_reuse_address = True
                 self.httpd = socketserver.TCPServer(("127.0.0.1", port), handler)
                 self.httpd.serve_forever()
             except Exception as e:

--- a/app/gui/tabs/superplat_tab.py
+++ b/app/gui/tabs/superplat_tab.py
@@ -8,6 +8,7 @@ from PyQt6.QtCore import pyqtSignal, QTimer
 from app.core.i18n import tr, add_language_observer
 from app.core.superplat_engine import SuperSplatEngine
 from app.gui.widgets.dialog_utils import get_open_file_name
+from urllib.parse import quote
 
 class SuperSplatTab(QWidget):
     """Onglet pour SuperSplat"""
@@ -128,6 +129,8 @@ class SuperSplatTab(QWidget):
                 success_data, msg_data = self.engine.start_data_server(str(directory), self.data_port.value())
                 if not success_data:
                     QMessageBox.warning(self, tr("msg_warning"), f"Erreur Serveur Données: {msg_data}")
+                    self.engine.stop_supersplat()
+                    return
 
         self.is_running = True
         self.btn_start.setText(tr("btn_stop_supersplat", "Arrêter SuperSplat"))
@@ -159,7 +162,7 @@ class SuperSplatTab(QWidget):
                 filename = path.name
                 # URL to data server
                 data_url = f"http://localhost:{self.data_port.value()}/{filename}"
-                params.append(f"load={data_url}")
+                params.append(f"load={quote(data_url, safe=':/')}")
             
         # No UI
         if self.chk_no_ui.isChecked():


### PR DESCRIPTION
## Summary
- allow the SuperSplat data server to serve an explicitly selected local PLY folder outside the app project directory
- stop the SuperSplat viewer if the data server fails to start, avoiding a broken viewer URL
- URL-encode the `load=` parameter before opening SuperSplat
- enable address reuse for the local data server socket

## Root cause
The data server rejected user output paths outside the CorbeauSplat project root with `Dossier de données hors du répertoire du projet`. Brush exports commonly live in an external results folder, so the viewer could launch but fail to fetch the selected PLY.

The server still binds to `127.0.0.1` and only serves the exact folder selected by the user.

## Validation
- `python3 -m py_compile app/core/superplat_engine.py app/gui/tabs/superplat_tab.py`
- `git diff --check`
- Started the data server against `/Users/eliel/Dropbox/Fun Codes/3Dfun/results/Brucegard/checkpoints` and confirmed `Brucegard_export_50000.ply` returns `200 OK` via HTTP HEAD.
